### PR TITLE
Halt if token, endpoint or module name not set.

### DIFF
--- a/Notify-Slack.ps1
+++ b/Notify-Slack.ps1
@@ -1,5 +1,16 @@
 $token = $Env:SlackToken
 $module = $Env:Docker_CI_ModuleName
+
+if (!$token) {
+    throw ("token not set, cannot publish to slack.")
+}
+if (!$Env:SlackURI) {
+    thow ("Slack integration endpoint not set, cannot publish to slack.")
+}
+if (!$module) {
+    throw ("module name not set, cannot publish to slack.")
+}
+
 $slackURI = "${Env:SlackURI}=${token}"
 $version = "${Env:GitVersion_Version}${Env:GitVersion_PreReleaseTagWithDash}"
 $slackChannel = 'batcave'


### PR DESCRIPTION
To fix the current situation where a malformed message gets sent to slack.