### PR TITLE
Write usable log output

### DIFF
--- a/Source/Private/Invoke-Command.ps1
+++ b/Source/Private/Invoke-Command.ps1
@@ -37,14 +37,15 @@ function Invoke-Command {
             }'
         $eventHandlerSource = $eventHandlerSource.Replace("WriteLogging", !$Quiet.IsPresent)
 
-        $eventHandler = [ScriptBlock]::Create($eventHandlerSource)
+        $stdOutHandlerSource = [ScriptBlock]::Create($eventHandlerSource)
+        $stdErrHandlerSource = [ScriptBlock]::Create($eventHandlerSource)
 
         $stdOutEventHandler = Register-ObjectEvent -InputObject $process `
-            -Action $eventHandler -EventName 'OutputDataReceived' `
+            -Action $stdOutHandlerSource -EventName 'OutputDataReceived' `
             -MessageData $stdOutMessages
 
         $stdErrEventHandler = Register-ObjectEvent -InputObject $process `
-            -Action $eventHandler -EventName 'ErrorDataReceived' `
+            -Action $stdErrHandlerSource -EventName 'ErrorDataReceived' `
             -MessageData $stdErrMessages
 
         $process.Start() | Out-Null

--- a/Source/Private/Invoke-Command.ps1
+++ b/Source/Private/Invoke-Command.ps1
@@ -74,6 +74,7 @@ function Invoke-Command {
         $processId = $process.Id
         $result.ExitCode = $process.ExitCode
         $process.Close()
+
         $finished = $true
     } finally {
         Unregister-Event -SourceIdentifier $stdOutEventHandler.Name
@@ -82,12 +83,20 @@ function Invoke-Command {
         # way kill the process
         try {
             if (-not $finished -or -not $process.HasExited) {
-                Write-Debug "Cleanup, kill the process with id $processId"
+                $message = "Cleanup, kill the process with id $processId"
+                Write-Debug $message
+                if (!$Quiet) {
+                    Write-CommandOuput $message
+                }
                 $process.Kill()
             }
         } catch {
             # This can happen if the process was never started in which case WaitForExit or HasExited throws an exception.
-            Write-Debug "Exception caught while trying to kill process id $processId, exception: $_"
+            $message = "Exception caught while trying to kill process id $processId, exception: $_"
+            Write-Debug $message
+            if (!$Quiet) {
+                Write-CommandOuput $message
+            }
         }
     }
     $result.StdOut = $stdOutMessages.ToArray()

--- a/Source/Private/Invoke-Command.ps1
+++ b/Source/Private/Invoke-Command.ps1
@@ -1,5 +1,5 @@
 # Copied from here: https://github.com/dotnet/roslyn/blob/master/src/Setup/Installer/tools/utils.ps1
-
+. "$PSScriptRoot\Write-PassThruOutput.ps1"
 function Invoke-Command {
     [CmdletBinding(PositionalBinding = $false)]
     param (

--- a/Source/Public/Invoke-DockerTag.ps1
+++ b/Source/Public/Invoke-DockerTag.ps1
@@ -45,7 +45,7 @@ function Invoke-DockerTag {
         'CommandResult' = $commandResult
     }
     if (!$Quiet) {
-        Write-CommandOuput $($commandResult.Output)
+        Write-CommandOuput ("tagged ${source} as ${target}")
     }
     return $result
 }

--- a/Source/Public/Invoke-DockerTag.ps1
+++ b/Source/Public/Invoke-DockerTag.ps1
@@ -45,7 +45,7 @@ function Invoke-DockerTag {
         'CommandResult' = $commandResult
     }
     if (!$Quiet) {
-        Write-CommandOuput ("tagged ${source} as ${target}")
+        Write-CommandOuput ("tagged '${source}' as '${target}'")
     }
     return $result
 }

--- a/Test-Source/Invoke-DockerTag.Tests.ps1
+++ b/Test-Source/Invoke-DockerTag.Tests.ps1
@@ -183,7 +183,7 @@ Describe 'Tag docker images' {
             Invoke-DockerTag -Quiet:$false -Registry 'artifactoryfqdn' -ImageName 'oldname' -NewImageName 'newimage' 6> $tempFile
 
             $result = Get-Content $tempFile
-            $result | Should -Be @('Hello', 'World')
+            $result | Should -Be @("tagged 'artifactoryfqdn/oldname:latest' as 'newimage:latest'")
         }
 
         It 'suppresses output if Quiet is enabled' {
@@ -193,7 +193,7 @@ Describe 'Tag docker images' {
             Invoke-DockerTag -Quiet:$enable -Registry 'artifactoryfqdn' -ImageName 'oldname' -NewImageName 'newimage' 6> $tempFile
 
             $result = Get-Content $tempFile
-            $result | Should -Be @('Hello', 'World')
+            $result | Should -Be @("tagged 'artifactoryfqdn/oldname:latest' as 'newimage:latest'")
         }
 
     }


### PR DESCRIPTION
Make sure the log output is helpful.
Also includes more fixes to a concurrency issue that can arise if messages to stdout and stderr happen at the exact same point in time.

Fixes #90 