### PR TITLE
Temporarily disable test.

### DIFF
--- a/Test-Source/Invoke-Command.Tests.ps1
+++ b/Test-Source/Invoke-Command.Tests.ps1
@@ -44,7 +44,7 @@ Describe 'Runs only external tools' {
         }
 
         It 'returns correct output and exit code, verbosely' {
-            if ($IsWindows) {
+            if ($IsLinux) {
                 Set-ItResult -Skipped -Because 'There is a bug in the Linux implementation of Process.WaitForExit() that seems to not wait for all async event handlers. This results in this test sometimes failing with a empty result from stdout or stderr.'
             }
             $result = Invoke-Command -Command $command.Command -CommandArgs $command.CommandArgs -Quiet:$false 6> $tempFile

--- a/Test-Source/Invoke-Command.Tests.ps1
+++ b/Test-Source/Invoke-Command.Tests.ps1
@@ -44,6 +44,9 @@ Describe 'Runs only external tools' {
         }
 
         It 'returns correct output and exit code, verbosely' {
+            if ($IsWindows) {
+                Set-ItResult -Skipped -Because 'There is a bug in the Linux implementation of Process.WaitForExit() that seems to not wait for all async event handlers. This results in this test sometimes failing with a empty result from stdout or stderr.'
+            }
             $result = Invoke-Command -Command $command.Command -CommandArgs $command.CommandArgs -Quiet:$false 6> $tempFile
 
             $result.ExitCode | Should -Be 0


### PR DESCRIPTION
Suggestion on how to 'fix' the flaky test.
We will have to accept poorer test coverage, but I think that is preferable to flaky tests that mean we can't trust CI/CD.