### PR TITLE
Switch gitversion mode

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,7 @@
-continuous-delivery-fallback-tag: ""
-
 branches:
+  master:
+    tag: beta
+
   # Merge/Pull requests
   pull-request:
     regex: '(MR-\d+-merge)|^(pull|pull\-requests|pr)[/-]'

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,3 @@
-mode: ContinuousDeployment
 continuous-delivery-fallback-tag: ""
 
 branches:


### PR DESCRIPTION
Due to a misunderstanding master was to use ContinuousDeployment.
We should use ContinousDelivery.
ContinousDelivery does not increment the version with each commit.